### PR TITLE
fix(EditorBuildSettings.asset)

### DIFF
--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -28,7 +28,7 @@ EditorBuildSettings:
     guid: a0eb7c940473afa4da4ba1228cf8019f
   - enabled: 1
     path: Assets/Scenes/Merge_25_09_16/6_WeaponSelectMode.unity
-    guid: 9d8934ed6e405564b8105019abf268dd
+    guid: d48ffdf52badc424cb8fb4f8472a692d
   - enabled: 1
     path: Assets/Scenes/Merge_25_09_16/7_InGameScene.unity
     guid: ef3b1e7ace3633d4a82b1d800184a1cf


### PR DESCRIPTION
무기 선택 씬이 연결되지 않은 문제를 해결하였습니다
close #33 